### PR TITLE
feat: add cluster_id into trace/profiling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21.0
 
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.26.0
-	github.com/CloudDetail/apo-module/apm/client v0.0.0-20250326032139-c96a724395fc
+	github.com/CloudDetail/apo-module/apm/client v0.0.0-20250618093713-7edf91dda667
 	github.com/CloudDetail/apo-module/apm/model v0.0.0-20250326032139-c96a724395fc
 	github.com/CloudDetail/apo-module/model v0.0.0-20250618093713-7edf91dda667
 	github.com/CloudDetail/apo-module/slo/api v0.0.0-20250326032139-c96a724395fc

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.26.0
 	github.com/CloudDetail/apo-module/apm/client v0.0.0-20250326032139-c96a724395fc
 	github.com/CloudDetail/apo-module/apm/model v0.0.0-20250326032139-c96a724395fc
-	github.com/CloudDetail/apo-module/model v0.0.0-20250326032139-c96a724395fc
+	github.com/CloudDetail/apo-module/model v0.0.0-20250618093713-7edf91dda667
 	github.com/CloudDetail/apo-module/slo/api v0.0.0-20250326032139-c96a724395fc
 	github.com/CloudDetail/apo-module/slo/sdk v0.0.0-20250326032139-c96a724395fc
 	github.com/CloudDetail/metadata v0.0.0-20241129101557-10d59745e7b7

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21.0
 
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.26.0
-	github.com/CloudDetail/apo-module/apm/client v0.0.0-20250618093713-7edf91dda667
+	github.com/CloudDetail/apo-module/apm/client v0.0.0-20250625022830-f240d8d2ffb5
 	github.com/CloudDetail/apo-module/apm/model v0.0.0-20250326032139-c96a724395fc
 	github.com/CloudDetail/apo-module/model v0.0.0-20250618093713-7edf91dda667
 	github.com/CloudDetail/apo-module/slo/api v0.0.0-20250326032139-c96a724395fc

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/CloudDetail/apo-module/apm/model v0.0.0-20250326032139-c96a724395fc h
 github.com/CloudDetail/apo-module/apm/model v0.0.0-20250326032139-c96a724395fc/go.mod h1:1CHcR5KaNC6ae6Wj41ONYKeDqxuS4IBpgBdMcxgPzfk=
 github.com/CloudDetail/apo-module/model v0.0.0-20250326032139-c96a724395fc h1:ZcIzlWIRlGRFmf4naVwXISgRdnwFpTJf/YkpUjpY/nQ=
 github.com/CloudDetail/apo-module/model v0.0.0-20250326032139-c96a724395fc/go.mod h1:9ZJgmGZcFO1Xa70ZRg000j3up8oo33wFeqTTAggilP8=
+github.com/CloudDetail/apo-module/model v0.0.0-20250618093713-7edf91dda667 h1:GNx47UIstl9uYeAuvMQHrSFaLMmH6w9WDhsbq5w/3GA=
+github.com/CloudDetail/apo-module/model v0.0.0-20250618093713-7edf91dda667/go.mod h1:9ZJgmGZcFO1Xa70ZRg000j3up8oo33wFeqTTAggilP8=
 github.com/CloudDetail/apo-module/slo/api v0.0.0-20250326032139-c96a724395fc h1:HaxjeeN0rUeU+xmZSBLZrS1u/oANVhOzzcaBE46togw=
 github.com/CloudDetail/apo-module/slo/api v0.0.0-20250326032139-c96a724395fc/go.mod h1:zdaGJlYJ4RGAXdSZZYEW3kLwnLSu8BFQHQv0j+PHk7E=
 github.com/CloudDetail/apo-module/slo/sdk v0.0.0-20250326032139-c96a724395fc h1:qwrSoRsCBIh8T7xVhXVAV64oqmU45Lo4TpJ9wMbG1J0=

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/ClickHouse/clickhouse-go/v2 v2.26.0 h1:j4/y6NYaCcFkJwN/TU700ebW+nmsIy
 github.com/ClickHouse/clickhouse-go/v2 v2.26.0/go.mod h1:iDTViXk2Fgvf1jn2dbJd1ys+fBkdD1UMRnXlwmhijhQ=
 github.com/CloudDetail/apo-module/apm/client v0.0.0-20250326032139-c96a724395fc h1:8HRVYPPzqrwhilUapjbSUxbJoB6eM7ZE7zTXX70LYSU=
 github.com/CloudDetail/apo-module/apm/client v0.0.0-20250326032139-c96a724395fc/go.mod h1:zF+uNa3aDPc36aSV4wKS0GHNFtgh6Rj12du5XaCErrs=
+github.com/CloudDetail/apo-module/apm/client v0.0.0-20250618093713-7edf91dda667 h1:DgGb605+1LDXzEdmZZi7cYEHxHUPKTzl4bzVOxP25T0=
+github.com/CloudDetail/apo-module/apm/client v0.0.0-20250618093713-7edf91dda667/go.mod h1:zF+uNa3aDPc36aSV4wKS0GHNFtgh6Rj12du5XaCErrs=
 github.com/CloudDetail/apo-module/apm/model v0.0.0-20250326032139-c96a724395fc h1:N4lXKF+gnEoxI5SSh7RNxD4F77fuqMBawM8TICSyA98=
 github.com/CloudDetail/apo-module/apm/model v0.0.0-20250326032139-c96a724395fc/go.mod h1:1CHcR5KaNC6ae6Wj41ONYKeDqxuS4IBpgBdMcxgPzfk=
 github.com/CloudDetail/apo-module/model v0.0.0-20250326032139-c96a724395fc h1:ZcIzlWIRlGRFmf4naVwXISgRdnwFpTJf/YkpUjpY/nQ=

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,8 @@ github.com/CloudDetail/apo-module/apm/client v0.0.0-20250326032139-c96a724395fc 
 github.com/CloudDetail/apo-module/apm/client v0.0.0-20250326032139-c96a724395fc/go.mod h1:zF+uNa3aDPc36aSV4wKS0GHNFtgh6Rj12du5XaCErrs=
 github.com/CloudDetail/apo-module/apm/client v0.0.0-20250618093713-7edf91dda667 h1:DgGb605+1LDXzEdmZZi7cYEHxHUPKTzl4bzVOxP25T0=
 github.com/CloudDetail/apo-module/apm/client v0.0.0-20250618093713-7edf91dda667/go.mod h1:zF+uNa3aDPc36aSV4wKS0GHNFtgh6Rj12du5XaCErrs=
+github.com/CloudDetail/apo-module/apm/client v0.0.0-20250625022830-f240d8d2ffb5 h1:fra4dQbyWhaV1hBxqbdivGUISNILxoXcmw5Fo9bzOjw=
+github.com/CloudDetail/apo-module/apm/client v0.0.0-20250625022830-f240d8d2ffb5/go.mod h1:zF+uNa3aDPc36aSV4wKS0GHNFtgh6Rj12du5XaCErrs=
 github.com/CloudDetail/apo-module/apm/model v0.0.0-20250326032139-c96a724395fc h1:N4lXKF+gnEoxI5SSh7RNxD4F77fuqMBawM8TICSyA98=
 github.com/CloudDetail/apo-module/apm/model v0.0.0-20250326032139-c96a724395fc/go.mod h1:1CHcR5KaNC6ae6Wj41ONYKeDqxuS4IBpgBdMcxgPzfk=
 github.com/CloudDetail/apo-module/model v0.0.0-20250326032139-c96a724395fc h1:ZcIzlWIRlGRFmf4naVwXISgRdnwFpTJf/YkpUjpY/nQ=

--- a/pkg/clickhouse/tables/flame_graph.go
+++ b/pkg/clickhouse/tables/flame_graph.go
@@ -38,6 +38,7 @@ type FlameGraphEvent struct {
 	NsPid       int    `json:"ns_pid"`
 	NodeName    string `json:"node_name"`
 	NodeIp      string `json:"node_ip"`
+	ClusterID   string `json:"cluster_id"`
 	SampleType  string `json:"sample_type"`
 	SampleRate  uint32 `json:"sample_rate"`
 	TraceId     string `json:"trace_id"`
@@ -69,6 +70,7 @@ func WriteFlameGraph(ctx context.Context, conn *sql.DB, toSends []string) error 
 			labels := map[string]string{
 				"node_name":    flameGraphEvent.NodeName,
 				"node_ip":      flameGraphEvent.NodeIp,
+				"cluster_id":   flameGraphEvent.ClusterID,
 				"container_id": flameGraphEvent.ContainerId,
 				"ns_pid":       strconv.Itoa(flameGraphEvent.NsPid),
 			}

--- a/pkg/clickhouse/tables/jvm_gc.go
+++ b/pkg/clickhouse/tables/jvm_gc.go
@@ -40,6 +40,7 @@ type JvmGcInfo struct {
 	Pid              string `json:"pid"`
 	NodeName         string `json:"node_name"`
 	NodeIp           string `json:"node_ip"`
+	ClusterID        string `json:"cluster_id"`
 	Ygc              int64  `json:"ygc"`
 	Fgc              int64  `json:"fgc"`
 	LastYgc          int64  `json:"last_ygc"`
@@ -71,8 +72,9 @@ func WriteJvmGcs(ctx context.Context, conn *sql.DB, toSends []string) error {
 				continue
 			}
 			labels := map[string]string{
-				"node_name": jvmGc.NodeName,
-				"node_ip":   jvmGc.NodeIp,
+				"node_name":  jvmGc.NodeName,
+				"node_ip":    jvmGc.NodeIp,
+				"cluster_id": jvmGc.ClusterID,
 			}
 			_, err = statement.ExecContext(ctx,
 				asTime(int64(jvmGc.Timestamp)), // NanoTime

--- a/pkg/clickhouse/tables/profiling_event.go
+++ b/pkg/clickhouse/tables/profiling_event.go
@@ -52,6 +52,7 @@ type CameraProfileEvent struct {
 	ContainerId     string `json:"container_id"`
 	NodeName        string `json:"node_name"`
 	NodeIp          string `json:"node_ip"`
+	ClusterID       string `json:"cluster_id"`
 	EndTime         uint64 `json:"endTime"`
 	InnerCalls      string `json:"innerCalls"`
 	JavaFutexEvents string `json:"javaFutexEvents"`
@@ -88,6 +89,7 @@ func WriteProfilingEvents(ctx context.Context, conn *sql.DB, toSends []string) e
 				"container_id": eventGroup.Labels.ContainerId,
 				"node_name":    eventGroup.Labels.NodeName,
 				"node_ip":      eventGroup.Labels.NodeIp,
+				"cluster_id":   eventGroup.Labels.ClusterID,
 				"protocol":     eventGroup.Labels.Protocol,
 				"threadName":   eventGroup.Labels.ThreadName,
 			}

--- a/pkg/clickhouse/tables/span_trace.go
+++ b/pkg/clickhouse/tables/span_trace.go
@@ -107,6 +107,7 @@ func WriteSpanTraces(ctx context.Context, conn *sql.DB, toSends []*model.Trace) 
 				"namespace":          trace.Namespace,
 				"node_name":          traceLabel.NodeName,
 				"node_ip":            traceLabel.NodeIp,
+				"cluster_id":         traceLabel.ClusterID,
 				"onoff_metrics":      trace.OnOffMetrics,
 				"base_onoff_metrics": trace.BaseOnOffMetrics,
 				"base_range":         trace.BaseRange,

--- a/pkg/httpserver/http_server.go
+++ b/pkg/httpserver/http_server.go
@@ -100,6 +100,7 @@ func getThresholds(ctx iris.Context) {
 
 func realtimeSlowReport(ctx iris.Context) {
 	traceId := ctx.Params().GetString("traceId")
+	clusterID := ctx.Params().GetString("clusterId")
 
 	traces, err := global.CLICK_HOUSE.QueryTraces(ctx, traceId)
 	if err != nil {
@@ -107,7 +108,7 @@ func realtimeSlowReport(ctx iris.Context) {
 		return
 	}
 
-	result, clientCalls, err := global.TRACE_CLIENT.QueryMutatedSlowTraceTree(traceId, traces)
+	result, clientCalls, err := global.TRACE_CLIENT.QueryMutatedSlowTraceTree(ctx, clusterID, traceId, traces)
 	if err != nil {
 		responseWithError(ctx, err)
 		return
@@ -121,6 +122,7 @@ func realtimeSlowReport(ctx iris.Context) {
 
 func realtimeErrorReport(ctx iris.Context) {
 	traceId := ctx.Params().GetString("traceId")
+	clusterID := ctx.Params().GetString("clusterId")
 
 	traces, err := global.CLICK_HOUSE.QueryTraces(ctx, traceId)
 	if err != nil {
@@ -128,7 +130,7 @@ func realtimeErrorReport(ctx iris.Context) {
 		return
 	}
 
-	result, err := global.TRACE_CLIENT.QueryErrorTraceTree(traceId, traces)
+	result, err := global.TRACE_CLIENT.QueryErrorTraceTree(ctx, clusterID, traceId, traces)
 	if err != nil {
 		responseWithError(ctx, err)
 		return


### PR DESCRIPTION
## Summary by Sourcery

Add cluster identifier propagation to trace and profiling data by extending data models and ClickHouse write paths to include cluster_id.

New Features:
- Add ClusterID field to JVM GC, FlameGraphEvent, CameraProfileEvent, and span trace data models
- Include cluster_id label in ClickHouse insert statements for GC metrics, flame graphs, profiling events, and span traces

Build:
- Bump github.com/CloudDetail/apo-module/model dependency version