### PR TITLE
add int alert report tmp sql

### DIFF
--- a/sqlscript/create_table/alert_report.tmp.sql
+++ b/sqlscript/create_table/alert_report.tmp.sql
@@ -1,0 +1,34 @@
+CREATE TABLE IF NOT EXISTS alert_report{{if .Cluster}}_local ON CLUSTER {{.Cluster}}{{end}}
+(
+
+    `report_id` UUID DEFAULT generateUUIDv4(),
+
+    `report_type` LowCardinality(String) CODEC(ZSTD(1)),
+
+    `overview_timestamp` DateTime64(3),
+
+    `overview_detail` String CODEC(ZSTD(1)),
+
+    `overview_reason` String CODEC(ZSTD(1)),
+
+    `overview_tags` Map(String,
+ String) CODEC(ZSTD(1)),
+
+    `tags` Map(String,
+ String) CODEC(ZSTD(1)),
+
+    `topology` String CODEC(ZSTD(1)),
+
+    `rootcause` String CODEC(ZSTD(1)),
+
+    `rootcause_other` Array(String) CODEC(LZ4),
+
+    `suggest` Array(String) CODEC(LZ4),
+
+    `data` Array(String) CODEC(ZSTD(1))
+)
+ENGINE = {{if .Replication}}ReplicatedMergeTree{{else}}MergeTree(){{end}}
+PARTITION BY toDate(overview_timestamp)
+ORDER BY (report_type,overview_timestamp)
+    TTL toDateTime(overview_timestamp) + toIntervalDay({{.TTLDay}})
+    SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1


### PR DESCRIPTION
## Summary by Sourcery

Introduce a new ClickHouse table schema for alert reports, including UUID key, metadata and array fields, engine configuration, partitioning, ordering, and TTL management.

Enhancements:
- Add SQL script `alert_report.tmp.sql` to create `alert_report` temporary table with metadata, tags, rootcause arrays, and data fields
- Configure MergeTree/ReplicatedMergeTree engine with partition by `overview_timestamp`, order by `(report_type, overview_timestamp)`, and apply TTL and storage settings