### PR TITLE
add release-image.yml

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -1,0 +1,71 @@
+name: Release Image
+
+permissions:
+  contents: write
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'The tag to release'
+        required: true
+
+env:
+  REGISTRY_HOST: registry.cn-hangzhou.aliyuncs.com
+  COLLECTOR_CONTAINER_NAME: apo-collector
+
+jobs:
+  build-images:
+    runs-on: ubuntu-latest
+    outputs:
+      IMAGE_TAG_NAME: ${{ steps.build-image.outputs.IMAGE_TAG_NAME }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@4574d27a4764455b42196d70a065bc6853246a25
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5
+
+      - name: Log in to container registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
+        with:
+          registry: ${{ env.REGISTRY_HOST }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Generate image metadata
+        id: build-image
+        env:
+          BRANCH_NAME: ${{ github.ref_name }}
+          COMMIT_HASH: ${{ github.sha }}
+        run: |
+          echo "IMAGE_TAG_NAME=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
+          echo "COLLECTOR_IMAGE_FULL_TAG_AMD64=${{ env.REGISTRY_HOST }}/${{ secrets.REGISTRY_USERNAME }}/${{ env.COLLECTOR_CONTAINER_NAME }}:${IMAGE_TAG_NAME}" >> $GITHUB_ENV
+          echo "COLLECTOR_IMAGE_FULL_TAG_ARM64=${{ env.REGISTRY_HOST }}/${{ secrets.REGISTRY_USERNAME }}/${{ env.COLLECTOR_CONTAINER_NAME }}:${IMAGE_TAG_NAME}-arm64" >> $GITHUB_ENV
+
+      - name: Build and push AMD64 image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.COLLECTOR_IMAGE_FULL_TAG_AMD64 }}
+
+      - name: Build and push ARM64 image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/arm64
+          push: true
+          tags: ${{ env.COLLECTOR_IMAGE_FULL_TAG_ARM64 }}
+
+      - name: push tag
+        uses: anothrNick/github-tag-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CUSTOM_TAG: ${{ github.event.inputs.tag }}


### PR DESCRIPTION
## Summary by Sourcery

Add a new GitHub Actions workflow to manually release multi-architecture Docker images for apo-collector by tag

Enhancements:
- Set up QEMU and Docker Buildx to build and push both AMD64 and ARM64 images
- Generate and propagate image metadata including full registry tags
- Automatically push matching Git tags upon successful image release

CI:
- Introduce .github/workflows/release-image.yml with a workflow_dispatch input for specifying release tags