### PR TITLE
feat: support query from dataplane provider

### DIFF
--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -16,6 +16,7 @@ import (
 	"github.com/CloudDetail/apo-receiver/pkg/componment/onoffmetric"
 	"github.com/CloudDetail/apo-receiver/pkg/componment/profile"
 	"github.com/CloudDetail/apo-receiver/pkg/config"
+	"github.com/CloudDetail/apo-receiver/pkg/dataplane"
 	"github.com/CloudDetail/apo-receiver/pkg/global"
 	"github.com/CloudDetail/apo-receiver/pkg/metrics"
 	metricModel "github.com/CloudDetail/apo-receiver/pkg/metrics/model"
@@ -718,7 +719,29 @@ func (analyzer *ReportAnalyzer) checkTask() {
 }
 
 func (analyzer *ReportAnalyzer) queryServices(ctx context.Context, apmType string, traceId string, rootTrace *model.TraceLabels) ([]*apmmodel.OtelServiceNode, error) {
-	serviceNodes, err := global.TRACE_CLIENT.QueryServices(ctx, rootTrace.ClusterID, apmType, traceId, rootTrace)
+	var serviceNodes []*apmmodel.OtelServiceNode
+	var err error
+	if global.DATAPLANE_CLIENT != nil {
+		startTime := (int64(rootTrace.StartTime) - int64(3*time.Second)) / 1e3 // TODO check time unit
+		endTime := (int64(rootTrace.EndTime) + int64(3*time.Second)) / 1e3
+
+		var resp *dataplane.QueryTracesResponse
+		resp, err = global.DATAPLANE_CLIENT.QueryTrace(ctx, &dataplane.QueryTraceSpansRequest{
+			StartTime: startTime,
+			EndTime:   endTime,
+			Filter: dataplane.QueryTraceFilter{
+				TraceId: traceId,
+			},
+			Limit: 1,
+		})
+		if err != nil {
+			return nil, err
+		}
+		serviceNodes, err = dataplane.GetServiceNode(resp)
+	} else {
+		serviceNodes, err = global.TRACE_CLIENT.QueryServices(ctx, rootTrace.ClusterID, apmType, traceId, rootTrace)
+	}
+
 	// Record Metric
 	metrics.UpdateMetric(metricModel.MetricAdapterApmTraceCount, []string{
 		rootTrace.NodeName,

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -722,7 +722,7 @@ func (analyzer *ReportAnalyzer) queryServices(ctx context.Context, apmType strin
 	var serviceNodes []*apmmodel.OtelServiceNode
 	var err error
 	if global.DATAPLANE_CLIENT != nil {
-		startTime := (int64(rootTrace.StartTime) - int64(3*time.Second)) / 1e3 // TODO check time unit
+		startTime := (int64(rootTrace.StartTime) - int64(3*time.Second)) / 1e3
 		endTime := (int64(rootTrace.EndTime) + int64(3*time.Second)) / 1e3
 
 		var resp *dataplane.QueryTracesResponse

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -122,3 +122,7 @@ type K8sConfig struct {
 
 	MetaServerConfig *metaconfigs.MetaSourceConfig `mapstructure:"meta_server_config"`
 }
+
+type DataplaneConfig struct {
+	Address string `mapstructure:"address"`
+}

--- a/pkg/dataplane/dataplane.go
+++ b/pkg/dataplane/dataplane.go
@@ -1,0 +1,56 @@
+package dataplane
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+type DataplaneClient struct {
+	Address string
+	client  *http.Client
+}
+
+const (
+	TraceEndpoint  = "/datasource/queryTraces"
+	MetricEndpoint = "/datasource/queryMetrics"
+	LogEndpoint    = "/datasource/queryLogs"
+)
+
+func NewClient(address string) *DataplaneClient {
+	if !strings.HasPrefix(address, "http://") && !strings.HasPrefix(address, "https://") {
+		address = "http://" + address
+	}
+
+	return &DataplaneClient{
+		Address: address,
+		client:  &http.Client{},
+	}
+}
+
+func (c *DataplaneClient) post(endpoint string, req any) (*http.Response, error) {
+	reqBody, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	httpReq, err := http.NewRequest(http.MethodPost, c.Address+endpoint, bytes.NewReader(reqBody))
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.client.Do(httpReq)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		var bodyStr = ""
+		if body, err := io.ReadAll(resp.Body); err == nil {
+			bodyStr = string(body)
+		}
+		resp.Body.Close()
+		return nil, fmt.Errorf("[%d] at %s ,resp body: %s", resp.StatusCode, endpoint, bodyStr)
+	}
+	return resp, nil
+}

--- a/pkg/dataplane/query_trace.go
+++ b/pkg/dataplane/query_trace.go
@@ -15,6 +15,9 @@ func (c *DataplaneClient) QueryTrace(ctx context.Context, req *QueryTraceSpansRe
 	if err != nil {
 		return nil, err
 	}
+
+	defer resp.Body.Close()
+
 	var dr DataplaneTraceResponse
 	err = json.NewDecoder(resp.Body).Decode(&dr)
 	if err != nil {

--- a/pkg/dataplane/query_trace.go
+++ b/pkg/dataplane/query_trace.go
@@ -1,0 +1,255 @@
+package dataplane
+
+import (
+	"context"
+	"fmt"
+
+	"encoding/json"
+
+	apmmodel "github.com/CloudDetail/apo-module/apm/model/v1"
+	"github.com/CloudDetail/apo-module/model/v1"
+)
+
+func (c *DataplaneClient) QueryTrace(ctx context.Context, req *QueryTraceSpansRequest) (*QueryTracesResponse, error) {
+	resp, err := c.post(TraceEndpoint, req)
+	if err != nil {
+		return nil, err
+	}
+	var dr DataplaneTraceResponse
+	err = json.NewDecoder(resp.Body).Decode(&dr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse completion response, err: %w", err)
+	}
+
+	if dr.Success {
+		// Pick up the first trace
+		for _, traceResp := range dr.Data {
+			if len(traceResp.Error) > 0 {
+				continue
+			}
+			if len(traceResp.Data) > 0 {
+				return traceResp, nil
+			}
+		}
+	}
+	return nil, fmt.Errorf("trace not found")
+}
+
+type DataplaneTraceResponse struct {
+	Success bool                   `json:"success"`
+	Data    []*QueryTracesResponse `json:"data"`
+}
+
+// QueryTraceSpansRequest 定义查询Spans参数
+type QueryTraceSpansRequest struct {
+	ProviderId int              `json:"providerId"`      // 接入数据源ID
+	StartTime  int64            `json:"startTime"`       // 开始时间
+	EndTime    int64            `json:"endTime"`         // 结束时间
+	Filter     QueryTraceFilter `json:"filter"`          // 过滤条件
+	Limit      int64            `json:"limit,omitempty"` // 返回记录数量
+}
+
+// QueryTraceFilter 定义过滤条件
+type QueryTraceFilter struct {
+	Service     string `json:"service,omitempty"`     // 服务名
+	Operation   string `json:"operation,omitempty"`   // 操作名
+	Error       bool   `json:"error,omitempty"`       // 是否Error
+	MinDuration uint64 `json:"minDuration,omitempty"` // 最小耗时
+	MaxDuration uint64 `json:"maxDuration,omitempty"` // 最大耗时
+
+	TraceId string `json:"traceId,omitempty"` // traceID
+}
+
+type QueryTracesResponse struct {
+	ProviderId int          `json:"providerId"` // 接入数据源ID
+	ClusterId  string       `json:"clusterId"`  // 接入集群ID
+	DataSource string       `json:"dataSource"` // 接入数据源名称
+	Unit       string       `json:"unit"`       // Span返回单位
+	Data       []*OtelTrace `json:"data"`
+	HasData    bool         `json:"hasData"`
+	Error      string       `json:"error,omitempty"`
+}
+
+type OtelTrace struct {
+	TraceId string      `json:"traceId"`
+	Spans   []*OtelSpan `json:"spans"`
+}
+
+type OtelSpan struct {
+	StartTime   uint64             `json:"startTime"` // us
+	Duration    uint64             `json:"duration"`  // us
+	ServiceName string             `json:"serviceName"`
+	Name        string             `json:"name"`
+	SpanId      string             `json:"spanId,omitempty"`
+	TraceId     string             `json:"-"`
+	PSpanId     string             `json:"parentSpanId,omitempty"`
+	Kind        OtelSpanKind       `json:"spanKind"` // unspecified|internal|server|client|consumer|providerw
+	IsError     bool               `json:"isError"`
+	Attributes  map[string]string  `json:"attributes"`
+	Exceptions  []*model.Exception `json:"exceptions,omitempty"`
+}
+
+type OtelSpanKind string
+
+const (
+	SpanKindUnspecified = "unspecified"
+	SpanKindInternal    = "internal"
+	SpanKindServer      = "server"
+	SpanKindClient      = "client"
+	SpanKindProducer    = "producer"
+	SpanKindConsumer    = "consumer"
+)
+
+func (kind OtelSpanKind) IsExit() bool {
+	return kind == SpanKindClient || kind == SpanKindProducer
+}
+
+func PickClientCall(resp *QueryTracesResponse, spanId string) []*model.ApmClientCall {
+	if len(resp.Data) <= 0 {
+		return nil
+	}
+
+	var result []*model.ApmClientCall
+	for _, trace := range resp.Data {
+		spans := trace.Spans
+		var childSpans = make(map[string][]*OtelSpan, 0) // spanId -> childSpan
+		var serviceSpan *OtelSpan
+
+		for _, span := range spans {
+			children, find := childSpans[span.PSpanId]
+			if find {
+				childSpans[span.PSpanId] = append(children, span)
+			} else {
+				childSpans[span.PSpanId] = []*OtelSpan{span}
+			}
+
+			if span.SpanId == spanId {
+				serviceSpan = span
+			}
+		}
+
+		if serviceSpan == nil {
+			continue
+		}
+		clientCalls := rSearchClientCall(childSpans, serviceSpan)
+		if len(clientCalls) > 0 {
+			result = append(result, clientCalls...)
+		}
+	}
+	return result
+}
+
+func rSearchClientCall(childSpanMap map[string][]*OtelSpan, pSpan *OtelSpan) []*model.ApmClientCall {
+	childSpans, find := childSpanMap[pSpan.SpanId]
+	if !find {
+		return nil
+	}
+
+	var clientCalls []*model.ApmClientCall
+
+	for _, span := range childSpans {
+		if pSpan.Kind.IsExit() && !span.Kind.IsExit() {
+			clientCalls = append(clientCalls, newApmClientCall(pSpan, span))
+			continue
+		}
+		if span.ServiceName != pSpan.ServiceName {
+			continue
+		}
+		rs := rSearchClientCall(childSpanMap, span)
+		if len(rs) > 0 {
+			clientCalls = append(clientCalls, rs...)
+		}
+	}
+
+	return clientCalls
+}
+
+func newApmClientCall(clientSpan *OtelSpan, serverEntrySpan *OtelSpan) *model.ApmClientCall {
+	if serverEntrySpan == nil {
+		return &model.ApmClientCall{
+			ClientStartTime:  clientSpan.StartTime,
+			ClientEndTime:    clientSpan.StartTime + clientSpan.Duration,
+			ClientName:       clientSpan.Name,
+			ClientSpanId:     clientSpan.SpanId,
+			ClientAttributes: clientSpan.Attributes,
+			// ClientOriginalSpanId: clientSpan.OriginalSpanId(),
+			ServerDuration: 0,
+		}
+	}
+	return &model.ApmClientCall{
+		ClientStartTime:  clientSpan.StartTime,
+		ClientEndTime:    clientSpan.StartTime + clientSpan.Duration,
+		ClientName:       clientSpan.Name,
+		ClientSpanId:     clientSpan.SpanId,
+		ClientAttributes: clientSpan.Attributes,
+		// ClientOriginalSpanId: clientSpan.OriginalSpanId(),
+		ServerDuration: serverEntrySpan.Duration,
+		ServerName:     serverEntrySpan.ServiceName,
+	}
+}
+
+func GetServiceNode(resp *QueryTracesResponse) ([]*apmmodel.OtelServiceNode, error) {
+	trace, err := ConvertToOtelTrace(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return trace.GetServiceNodes(), nil
+}
+
+func ConvertToOtelTrace(resp *QueryTracesResponse) (*apmmodel.OTelTrace, error) {
+	data := resp.Data
+
+	var result []*apmmodel.OTelTrace
+	for _, trace := range data {
+		otelTrace := apmmodel.NewOTelTrace(resp.DataSource)
+		traceTree := apmmodel.NewOtelTree()
+
+		for _, span := range trace.Spans {
+			otelSpan := &apmmodel.OtelSpan{
+				StartTime:   span.StartTime,
+				Duration:    span.Duration,
+				ServiceName: span.ServiceName,
+				Name:        span.Name,
+				SpanId:      span.SpanId,
+				PSpanId:     span.PSpanId,
+				NextSpanId:  "",
+				Kind:        transSpanKind(span.Kind),
+				Code:        apmmodel.StatusCodeUnset,
+				NotSampled:  false,
+				Attributes:  span.Attributes,
+				Exceptions:  span.Exceptions,
+			}
+			err := traceTree.AddSpan(otelSpan)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		err := traceTree.BuildRelation4Spans(otelTrace)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, otelTrace)
+	}
+	return result[0], nil
+}
+
+func transSpanKind(kind OtelSpanKind) apmmodel.OtelSpanKind {
+	switch kind {
+	case SpanKindUnspecified:
+		return apmmodel.SpanKindUnspecified
+	case SpanKindClient:
+		return apmmodel.SpanKindClient
+	case SpanKindServer:
+		return apmmodel.SpanKindServer
+	case SpanKindInternal:
+		return apmmodel.SpanKindInternal
+	case SpanKindProducer:
+		return apmmodel.SpanKindProducer
+	case SpanKindConsumer:
+		return apmmodel.SpanKindConsumer
+	default:
+		return apmmodel.SpanKindUnspecified
+	}
+}

--- a/pkg/global/componments.go
+++ b/pkg/global/componments.go
@@ -3,6 +3,7 @@ package global
 import (
 	"github.com/CloudDetail/apo-receiver/pkg/clickhouse"
 	"github.com/CloudDetail/apo-receiver/pkg/componment/redis"
+	"github.com/CloudDetail/apo-receiver/pkg/dataplane"
 
 	"github.com/CloudDetail/apo-module/apm/client/v1/api"
 )
@@ -12,4 +13,6 @@ var (
 	TRACE_CLIENT api.ApmTraceAPI
 	CACHE        redis.ExpirableCache
 	PROM_RANGE   string
+
+	DATAPLANE_CLIENT *dataplane.DataplaneClient
 )

--- a/pkg/receiver/receiver.go
+++ b/pkg/receiver/receiver.go
@@ -14,6 +14,7 @@ import (
 	"syscall"
 
 	"github.com/CloudDetail/apo-receiver/pkg/componment/agentmonitor"
+	"github.com/CloudDetail/apo-receiver/pkg/dataplane"
 
 	"github.com/CloudDetail/apo-receiver/pkg/componment/ebpffile"
 	"github.com/CloudDetail/apo-receiver/pkg/componment/redis"
@@ -46,9 +47,14 @@ func Run(ctx context.Context) error {
 	// Initialize flags
 	configPath := flag.String("config", "receiver-config.yml", "Configuration file")
 	flag.Parse()
-	receiverCfg, sampleCfg, profileCfg, prometheusCfg, clickHouseCfg, analyzerCfg, redisCfg, k8sCfg, err := readInConfig(*configPath)
+	receiverCfg, sampleCfg, profileCfg, prometheusCfg, clickHouseCfg, analyzerCfg, redisCfg, k8sCfg, dataplaneCfg, err := readInConfig(*configPath)
 	if err != nil {
 		return fmt.Errorf("fail to read configuration: %w", err)
+	}
+
+	if dataplaneCfg != nil && len(dataplaneCfg.Address) > 0 {
+		dpClient := dataplane.NewClient(dataplaneCfg.Address)
+		global.DATAPLANE_CLIENT = dpClient
 	}
 
 	if redisCfg.Enable {
@@ -136,12 +142,12 @@ func Run(ctx context.Context) error {
 	return nil
 }
 
-func readInConfig(path string) (*config.ReceiverConfig, *config.SampleConfig, *config.ProfileConfig, *config.PrometheusConfig, *config.ClickHouseConfig, *config.AnalyzerConfig, *config.RedisConfig, *config.K8sConfig, error) {
+func readInConfig(path string) (*config.ReceiverConfig, *config.SampleConfig, *config.ProfileConfig, *config.PrometheusConfig, *config.ClickHouseConfig, *config.AnalyzerConfig, *config.RedisConfig, *config.K8sConfig, *config.DataplaneConfig, error) {
 	viper := viper.New()
 	viper.SetConfigFile(path)
 	err := viper.ReadInConfig()
 	if err != nil { // Handle errors reading the config file
-		return nil, nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("error happened while reading config file: %w", err)
+		return nil, nil, nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("error happened while reading config file: %w", err)
 	}
 	receiverCfg := &config.ReceiverConfig{}
 	_ = viper.UnmarshalKey("receiver", receiverCfg)
@@ -167,7 +173,10 @@ func readInConfig(path string) (*config.ReceiverConfig, *config.SampleConfig, *c
 	k8sCfg := &config.K8sConfig{}
 	_ = viper.UnmarshalKey("k8s", k8sCfg)
 
-	return receiverCfg, sampleCfg, profileCfg, prometheusCfg, clickHouseCfg, analyzerCfg, redisCfg, k8sCfg, nil
+	dataplaneCfg := &config.DataplaneConfig{}
+	_ = viper.UnmarshalKey("dataplane", dataplaneCfg)
+
+	return receiverCfg, sampleCfg, profileCfg, prometheusCfg, clickHouseCfg, analyzerCfg, redisCfg, k8sCfg, dataplaneCfg, nil
 }
 
 func startGrpcServer(


### PR DESCRIPTION
This PR enables the APO Receiver to query Trace data from Dataplane and generate the span_trace and service_relation datasets required for complex root cause analysis.

## Summary by Sourcery

Add integration with an external dataplane provider to query trace spans and generate service relation datasets for complex root cause analysis. Introduce a new DataplaneClient package, wire in configuration and global client initialization, and update the analyzer to use dataplane queries with a fallback to the existing trace client.

New Features:
- Introduce pkg/dataplane with DataplaneClient for HTTP-based trace querying.
- Support dataplane provider configuration and initialize DataplaneClient in the receiver.
- Update analyzer to fetch service nodes via DataplaneClient when configured.

Enhancements:
- Fallback to the default APM trace client if DataplaneClient is not configured.
- Add conversion utilities to transform dataplane responses into OtelTrace and service nodes.